### PR TITLE
Fix some display flex issues

### DIFF
--- a/Autodize.Client/Components/Tumbler.razor
+++ b/Autodize.Client/Components/Tumbler.razor
@@ -33,16 +33,20 @@
         }
     }
 
+    <MudFlexBreak/>
+
     @if (IsDiceLimitAlertVisible)
     {
-        <MudItem xs="12">
+        <MudItem xs="12" md="8" lg="6" xl="4">
             <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined" ShowCloseIcon="true" CloseIconClicked="() => IsDiceLimitAlertVisible = false">
                 The max number of dice is currently 100 due to UX limitations of the UI framework. Leave an issue on GitHub if you need more, or better yet, make a PR! :)
             </MudAlert>
         </MudItem>
     }
 
-    <MudItem xs="12">
+    <MudFlexBreak/>
+    
+    <MudItem xs="12" md="8" lg="6" xl="4">
         <MudPaper>
             <MudToolBar Class="d-flex gap-4 sticky" Dense="true" Gutters="true">
                 <MudIconButton Icon="@Icons.Material.Outlined.Menu" Color="Color.Inherit" Class="mr-5"
@@ -65,6 +69,9 @@
                     <MudButton OnClick="@ExpandAllGroups" Color="@Color.Primary">Expand All</MudButton>
                     <MudButton OnClick="@CollapseAllGroups" Color="@Color.Primary">Collapse All</MudButton>
                 </MudItem>
+
+                <MudFlexBreak/>
+                
                 <MudItem xs="12" md="8" lg="6" xl="4">
                     <MudDataGrid @ref="_dataGrid" Items="Results" Filterable="true"
                                  Hideable="true" Groupable="true" GroupExpanded="false" Dense="true" RowsPerPage="100">
@@ -89,6 +96,9 @@
                         </PagerContent>
                     </MudDataGrid>
                 </MudItem>
+
+                <MudFlexBreak/>
+                
                 <MudItem xs="12" md="8" lg="6" xl="4">
                     <MudButton OnClick="@ExpandAllGroups" Color="@Color.Primary">Expand All</MudButton>
                     <MudButton OnClick="@CollapseAllGroups" Color="@Color.Primary">Collapse All</MudButton>


### PR DESCRIPTION
This pull request introduces layout improvements to the `Tumbler.razor` component in the `Autodize.Client` project. The changes enhance the responsiveness and visual spacing of the UI by adding `MudFlexBreak` components and updating grid item sizing.

### Layout improvements:

* Added `MudFlexBreak` components throughout the file to improve spacing and layout separation between UI elements. These breaks ensure better alignment and readability on different screen sizes. [[1]](diffhunk://#diff-e40a2fc911df23c2155a01c0777e3d019678f11bd76b4a7c275260aa989967b8R36-R49) [[2]](diffhunk://#diff-e40a2fc911df23c2155a01c0777e3d019678f11bd76b4a7c275260aa989967b8R72-R74) [[3]](diffhunk://#diff-e40a2fc911df23c2155a01c0777e3d019678f11bd76b4a7c275260aa989967b8R99-R101)
* Updated `MudItem` grid sizing attributes (`xs`, `md`, `lg`, `xl`) to make the layout more responsive and consistent across various screen sizes. For example, the alert and grid items now use `xs="12" md="8" lg="6" xl="4"` for better scaling. [[1]](diffhunk://#diff-e40a2fc911df23c2155a01c0777e3d019678f11bd76b4a7c275260aa989967b8R36-R49) [[2]](diffhunk://#diff-e40a2fc911df23c2155a01c0777e3d019678f11bd76b4a7c275260aa989967b8R72-R74) [[3]](diffhunk://#diff-e40a2fc911df23c2155a01c0777e3d019678f11bd76b4a7c275260aa989967b8R99-R101)